### PR TITLE
fix: use zsh in sshcode script

### DIFF
--- a/bin/sshcode
+++ b/bin/sshcode
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 
 sshcode() {
   set -x


### PR DESCRIPTION
## Summary
- fix sshcode interpreter to use zsh so zparseopts works

## Testing
- `pre-commit run --files bin/sshcode` *(fails: command not found: pre-commit)*
- `zsh test/main.zsh` *(fails: command not found: zsh)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bc849c388324b8d5c053320c20c9