### PR TITLE
fix: rename palette script

### DIFF
--- a/bin/256palette.sh
+++ b/bin/256palette.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Color pallete checker for shell
+# Color palette checker for shell
 
 for C in {0..255}; do
   tput setab "$C"


### PR DESCRIPTION
## Summary
- rename 256 color palette script with correct spelling
- clarify script comment

## Testing
- `pre-commit run --files bin/256palette.sh` *(fails: pre-commit not installed, 403 when installing)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c0f9cf288324a394ea97ccc4b42a