### PR TITLE
Use printf for unknown archive errors

### DIFF
--- a/bin/extract
+++ b/bin/extract
@@ -25,7 +25,7 @@ extract() {
     *.ace) unace e "$full_path" ;;
     *.xpi) unzip "$full_path" ;;
     *)
-      print "Unknown archive type: $1"
+      printf '%s\n' "Unknown archive type: $1"
       return 1
       ;;
   esac


### PR DESCRIPTION
## Summary
- use `printf '%s\n'` instead of `print` in `bin/extract`

## Testing
- `bin/extract testfile.unknown`
- `bin/extract testfile.unknown >/dev/null; printf 'exit status=%s\n' $?`
- `make test` *(fails: /bin/zsh: No such file or directory)*
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y zsh` *(fails: Unable to locate package zsh)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c101a1c0832490e6f6f415eb3119