### PR TITLE
Fix update/upgrade comment typo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,7 +117,7 @@ update_packages() {
   elif [ "$_distro" = "redhat" ]; then
     sudo yum update -y
   elif [ "$_distro" = "arch" ]; then
-    sudo pacman -Syyu  # udpate & upgrade
+    sudo pacman -Syyu  # update & upgrade
   elif [ "$_distro" = "alpine" ]; then
     sudo apk update
   else


### PR DESCRIPTION
## Summary
- fix typo in pacman update comment

## Testing
- `make test` *(fails: `/bin/zsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c11b79148324a305220e5be7fcfd